### PR TITLE
Missions

### DIFF
--- a/src/components/Mission.js
+++ b/src/components/Mission.js
@@ -1,7 +1,83 @@
-import React from 'react';
+import PropTypes from 'prop-types';
+import { useDispatch } from 'react-redux';
+import { join, leave } from '../redux/missions/missionSlice';
 
-export default function Missions() {
+// Define the Mission component as a function declaration to follow the ESLint rule
+function Mission({
+  mission,
+  description,
+  id,
+  reserved,
+}) {
+  const dispatch = useDispatch();
+
+  const missionJoin = (id) => {
+    dispatch(join(id));
+  };
+
+  const missionLeave = (id) => {
+    dispatch(leave(id));
+  };
+
   return (
-    <div>Missions</div>
+    <tr>
+      <td>{mission}</td>
+      <td>{description}</td>
+      <td className="wide-td">
+        <span
+          className="member-span"
+          style={{
+            color: 'white',
+            backgroundColor: reserved ? '#47a6a5' : '#777',
+            border: 'none',
+            borderRadius: '3px',
+            cursor: 'default',
+            padding: '3px',
+          }}
+        >
+          {reserved ? 'Active Member' : 'Not a Member'}
+        </span>
+      </td>
+      <td className="wide-td">
+        {reserved ? (
+          <button
+            type="button"
+            onClick={() => missionLeave(id)}
+            style={{
+              border: '1px solid red',
+              backgroundColor: 'transparent',
+              color: 'red',
+              padding: '5px',
+              borderRadius: '4px',
+            }}
+          >
+            Leave Mission
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={() => missionJoin(id)}
+            style={{
+              border: '1px solid black',
+              backgroundColor: 'transparent',
+              color: 'black',
+              padding: '5px',
+              borderRadius: '4px',
+            }}
+          >
+            Join Mission
+          </button>
+        )}
+      </td>
+    </tr>
   );
 }
+
+Mission.propTypes = {
+  id: PropTypes.string.isRequired,
+  reserved: PropTypes.bool.isRequired,
+  mission: PropTypes.string.isRequired,
+  description: PropTypes.string.isRequired,
+};
+
+export default Mission;

--- a/src/components/Missions.js
+++ b/src/components/Missions.js
@@ -1,0 +1,53 @@
+import 'bootstrap/dist/css/bootstrap.min.css';
+import React, { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { nanoid } from '@reduxjs/toolkit';
+import { Table } from 'react-bootstrap';
+import { fetchMissions } from '../redux/missions/missionSlice';
+import Mission from './Mission';
+
+function Missions() {
+  const dispatch = useDispatch();
+  const missions = useSelector((state) => state.missions.missions);
+  const status = useSelector((state) => state.missions.status);
+
+  useEffect(() => {
+    if (status === 'idle') {
+      dispatch(fetchMissions());
+    }
+  }, [status, dispatch]);
+
+  if (status === 'loading') {
+    return <div>Loading...</div>;
+  } if (status === 'succeeded') {
+    return (
+      <Table striped bordered hover>
+        <thead>
+          <tr>
+            <th className="mission-name">Mission</th>
+            <th>Description</th>
+            <th>Status</th>
+            <th>Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {missions.map((mission) => (
+            <Mission
+              key={nanoid()}
+              id={mission.mission_id}
+              mission={mission.mission_name}
+              description={mission.description}
+              reserved={mission.reserved}
+            />
+          ))}
+        </tbody>
+      </Table>
+    );
+  } if (status === 'failed') {
+    return <div>Error loading missions.</div>;
+  }
+
+  return null;
+}
+
+export default Missions;


### PR DESCRIPTION
This pull request adds the Mission Section, which I’ve worked on to bring a dynamic and engaging feature to the Space Travelers' Hub. The mission section allows users to explore and manage their involvement in exciting space missions. Here’s an overview of the key features:

Key Features:
Mission List Display:
Users can view an up-to-date list of available space missions, with important details such as mission name, description, and mission status.

Join/Leave Missions Functionality:
Each mission includes an interactive "Join Mission" or "Leave Mission" button, allowing users to easily manage their participation in space missions.

Upon joining, users can see their mission status updated instantly.
The interface seamlessly reflects changes, enhancing user experience with real-time feedback.
Responsiveness:
The section has been designed to adapt perfectly to different screen sizes, ensuring smooth interaction on both mobile and desktop devices.

Dynamic Status Badges:
Users can quickly identify their mission participation status with clear, dynamic badges indicating "Active Member" or "Not A Member."

Why This Section Shines:
The mission section adds significant interactivity, empowering users to feel like they are part of real space expeditions.
The design is clean, yet powerful, ensuring an intuitive experience while reinforcing the project’s luxurious and futuristic feel.